### PR TITLE
Disable sharing of pipenv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,11 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+#
+#   At this point, usage of pipenv is up to individual contributors, so disabling pipenv
+#   files completely.
+Pipfile
+Pipfile.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/


### PR DESCRIPTION
Not using pipenv as an official development env at this point, so ignoring both pipfiles.
