### PR TITLE
Fix Mega-Linter workflow to refer to main

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -39,6 +39,7 @@
     "mkdocs",
     "mpiexec",
     "mypy",
+    "nosec",
     "nosetests",
     "nvuillam",
     "pipenv",

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -4,10 +4,10 @@
 name: Mega-Linter
 
 on:
-  # Trigger mega-linter at every push. Action will also be visible from Pull Requests to master
+  # Trigger mega-linter at every push. Action will also be visible from Pull Requests to the main branch
   push: # Comment this line to trigger action only on pull-requests (not recommended if you don't pay for GH Actions)
   pull_request:
-    branches: [master, main]
+    branches: main
 
 # env: # Comment env block if you do not want to apply fixes
 #  # Apply linter fixes configuration
@@ -45,7 +45,7 @@ jobs:
         env:
           # All available variables are described in documentation
           # https://nvuillam.github.io/mega-linter/configuration/
-          VALIDATE_ALL_CODEBASE: true # Set ${{ github.event_name == &#39;push&#39; &amp;&amp; github.ref == &#39;refs/heads/master&#39; }} to validate only diff with master branch
+          VALIDATE_ALL_CODEBASE: true # Set ${{ github.event_name == &#39;push&#39; &amp;&amp; github.ref == &#39;refs/heads/main&#39; }} to validate only diff with main branch
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # ADD YOUR CUSTOM ENV VARIABLES HERE TO OVERRIDE VALUES OF .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
 
@@ -77,10 +77,10 @@ jobs:
 
       # Push new commit if applicable (for now works only on PR from same repository, not from forks)
       - name: Prepare commit
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'commit' && github.ref != 'refs/heads/master' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.head_commit.message, 'skip fix')
+        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'commit' && github.ref != 'refs/heads/main' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.head_commit.message, 'skip fix')
         run: sudo chown -Rc $UID .git/
       - name: Commit and push applied linter fixes
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'commit' && github.ref != 'refs/heads/master' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.head_commit.message, 'skip fix')
+        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'commit' && github.ref != 'refs/heads/main' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.head_commit.message, 'skip fix')
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref }}

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[tool.isort]
+profile = "black"

--- a/pynodelauncher.py
+++ b/pynodelauncher.py
@@ -1,5 +1,7 @@
 import argparse
-import subprocess
+
+# Running subprocess is purpose of this tools, no security concern here.
+import subprocess  # nosec
 import sys
 
 from mpi4py import MPI

--- a/pynodelauncher.py
+++ b/pynodelauncher.py
@@ -118,8 +118,8 @@ def main():
                 break
             # No security concern here. The point is to execute arbitrary user code.
             completed_process = subprocess.run(
-                command, shell=True, check=False
-            )  # nosec
+                command, shell=True, check=False  # nosec
+            )
             result = completed_process.returncode
             if result:
                 print_error(

--- a/pynodelauncher.py
+++ b/pynodelauncher.py
@@ -114,7 +114,10 @@ def main():
             command = comm.recv(source=0, tag=0)
             if command == "QUIT":
                 break
-            completed_process = subprocess.run(command, shell=True, check=False)
+            # No security concern here. The point is to execute arbitrary user code.
+            completed_process = subprocess.run(
+                command, shell=True, check=False
+            )  # nosec
             result = completed_process.returncode
             if result:
                 print_error(


### PR DESCRIPTION
The Mega-Linter workflow has references to master, but the default branch was always main in this repo.
This fixes conditions, updates the name in comments, and removes the branch matching rule.
